### PR TITLE
fix: update sponsor section to link to GitHub Sponsors

### DIFF
--- a/static/scripts/main2.js
+++ b/static/scripts/main2.js
@@ -186,7 +186,3 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 });
-
-        });
-    });
-});

--- a/static/scripts/main2.js
+++ b/static/scripts/main2.js
@@ -186,3 +186,7 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 });
+
+        });
+    });
+});

--- a/templates/home2.html
+++ b/templates/home2.html
@@ -448,8 +448,8 @@
                     </div>
                     <div class="sample-content">
                         <h3 class="sample-title">Become a Sponsor</h3>
-                        <p>Companies can sponsor FPOImg and have their logo displayed on the generator images. Contact us for details.</p>
-                        <a href="https://form.typeform.com/to/ywHSwfZU" target="_blank" class="generate-btn" style="display: inline-block; margin-top: 1rem;">Sponsor Us</a>
+                        <p>Sponsor FPOImg on GitHub to help keep the project running and get recognition for your support.</p>
+                        <a href="https://github.com/sponsors/kylehayes" target="_blank" class="generate-btn" style="display: inline-block; margin-top: 1rem;">Sponsor on GitHub</a>
                     </div>
                 </div>
                 


### PR DESCRIPTION
Replaces the old Typeform sponsor link (which mentioned logos on images) with a direct link to the GitHub Sponsors page.